### PR TITLE
Configurable username regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ following environment variables:
 | `PORTUNUS_SLAPD_TLS_CA_CERTIFICATE` | *(optional)* | *Required* when a TLS certificate is given. The full chain of CA certificates which has signed the TLS certificate, *including the root CA*. |
 | `PORTUNUS_SLAPD_TLS_DOMAIN_NAME` | *(optional)* | *Required* when a TLS certificate is given. The domain name for which the certificate is valid. `portunus-server` will use this domain name when connecting to the LDAP server. |
 | `PORTUNUS_SLAPD_TLS_PRIVATE_KEY` | *(optional)* | *Required* when a TLS certificate is given. The path to the private key belonging to the TLS certificate. |
+| `PORTUNUS_POSIX_ACCOUNT_REGEX` | *(optional)* | Configures a username regex. |
 
 Root privileges are required for the orchestrator because it needs to setup runtime directories and
 bind the LDAP port which is a privileged port (389 without TLS, 636 with TLS). No process managed by


### PR DESCRIPTION
## Changes
This pull request makes the Username Regex configurable over an environment variable. 

## Motivation
Our organization wants to enforce some username schema with `firstname.secondname` and currently `.` are not allowed by the posix user regex. With those changes, we can configure portunus to our username schema

- `PORTUNUS_POSIX_ACCOUNT_REGEX` which takes the new username regex

## Tested 
- Compiling
- Adjusted Readme
- Rolled out on your nixos maschine:
   - added regexOption here https://github.com/NixOS/nixpkgs/commit/535b4ba699ad76ef3d57a33ac8415a4bec736dfe which I try to yeet into nixpkgs after this pr is done 