### PR TITLE
Introduce PORTUNUS_SERVER_TRUSTED_ORIGINS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ following environment variables:
 | `PORTUNUS_SERVER_GROUP`<br>`PORTUNUS_SERVER_USER` | `portunus` each | The Unix user/group that Portunus' own server will be run as. |
 | `PORTUNUS_SERVER_HTTP_LISTEN` | `127.0.0.1:8080` | Listen address where Portunus' HTTP server shall be running. |
 | `PORTUNUS_SERVER_HTTP_SECURE` | `true` | **Do not unset this flag in productive deployments.** In test deployments, this can be set to `false` so that the web GUI works without TLS. |
+| `PORTUNUS_SERVER_TRUSTED_ORIGINS` | `` | If running Portunus's HTTP server behind a reverse proxy, set this to a comma-delimited list of domain names it should serve its interface on. For example, `dir.mydomain.com,dir.myotherdomain.com`. |
 | `PORTUNUS_SERVER_STATE_DIR` | `/var/lib/portunus` | The path where Portunus stores its database. **Set up a backup for this directory.** |
 | `PORTUNUS_SLAPD_BINARY` | `slapd` | Where to find the binary of slapd (the OpenLDAP server). Semantics match those of `execvp(3)`: If the supplied value is not a path containing slashes, `$PATH` will be searched for it. The slapd binary must link against the same libcrypt as the Portunus binaries, otherwise there will be disagreement between both parties on how password hashes work. |
 | `PORTUNUS_SLAPD_GROUP`<br>`PORTUNUS_SLAPD_USER` | `ldap` each | The Unix user/group that slapd will be run as. |

--- a/cmd/portunus-server/main.go
+++ b/cmd/portunus-server/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/majewsky/portunus/internal/core"
@@ -53,7 +54,9 @@ func main() {
 		must.Succeed(ldapAdapter.Run(ctx))
 	}()
 
-	handler := frontend.HTTPHandler(nexus, os.Getenv("PORTUNUS_SERVER_HTTP_SECURE") == "true")
+	trustedOrigins := strings.Split(os.Getenv("PORTUNUS_SERVER_TRUSTED_ORIGINS"), ",")
+	httpSecure := os.Getenv("PORTUNUS_SERVER_HTTP_SECURE") == "true"
+	handler := frontend.HTTPHandler(nexus, httpSecure, trustedOrigins)
 	logg.Fatal(http.ListenAndServe(os.Getenv("PORTUNUS_SERVER_HTTP_LISTEN"), handler).Error())
 }
 

--- a/internal/frontend/core.go
+++ b/internal/frontend/core.go
@@ -24,7 +24,7 @@ import (
 )
 
 // HTTPHandler returns the main http.Handler.
-func HTTPHandler(nexus core.Nexus, isBehindTLSProxy bool) http.Handler {
+func HTTPHandler(nexus core.Nexus, isBehindTLSProxy bool, trustedOrigins []string) http.Handler {
 	r := mux.NewRouter()
 	r.Methods("GET").Path(`/`).Handler(getToplevelHandler(nexus))
 	r.Methods("GET").Path(`/static/{path:.+}`).Handler(http.StripPrefix("/static/", http.FileServer(http.FS(static.FS))))
@@ -54,7 +54,7 @@ func HTTPHandler(nexus core.Nexus, isBehindTLSProxy bool) http.Handler {
 
 	//setup CSRF with maxAge = 30 minutes
 	csrfKey := core.GenerateRandomKey(32)
-	csrfMiddleware := csrf.Protect(csrfKey, csrf.MaxAge(1800), csrf.Secure(isBehindTLSProxy))
+	csrfMiddleware := csrf.Protect(csrfKey, csrf.MaxAge(1800), csrf.Secure(isBehindTLSProxy), csrf.TrustedOrigins(trustedOrigins))
 	handler := csrfMiddleware(r)
 
 	//add various security headers via middleware


### PR DESCRIPTION
Currently, running the Portunus frontend behind a reverse proxy causes the error `Forbidden - origin invalid` to be thrown during handling of any form submissions. It looks like this error comes from the Gorilla CSRF library, which is configured without the `TrustedOrigins` option.

Expose this as `PORTUNUS_SERVER_TRUSTED_ORIGINS` environment variable, which may be set to a comma-delimited string containing such origins, e.g. `dir.domain.com`.